### PR TITLE
[FIX] Add explicit include to coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 omit =
     */main.py
+include =
+    */git_aggregator/*


### PR DESCRIPTION
I noticed a coverage drop when I edited the ReadMe in #8. This PR should fix that by providing an explicit includes for only python files in the package directory.