### PR TITLE
Typo fix.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ repositories at any time:
 
 Expand environment variables inside of the configuration file when loading:
 
-.. code-block: bash
+.. code-block:: bash
 
     $ gitaggregate -c repos.yaml --expand-env
 


### PR DESCRIPTION
Before, this block was being rendered as a comment (well... not rendered).

See:

![captura de pantalla de 2017-02-01 11-12-58](https://cloud.githubusercontent.com/assets/973709/22504752/d9bbdad6-e86f-11e6-8678-248374b3aaaf.png)


cc @Tecnativa @lasley 