### PR TITLE
shell_command_after: fix doc and add real life example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ the aggregated directory.
         merges:
             - oca 8.0
         target: acsone aggregated_branch_name
-            shell_command_after: echo 'my command'
+        shell_command_after: echo 'my command'
 
     ./connector-interfaces:
         remotes:
@@ -134,9 +134,10 @@ the aggregated directory.
         merges:
             - oca 9.0
         target: acsone aggregated_branch_name
-            shell_command_after:
-                - echo 'a first command'
-                - echo 'a second command'
+        shell_command_after:
+            - echo 'a first command'
+            - echo 'a second command'
+
 
 Command line Usage
 ==================

--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,19 @@ the aggregated directory.
             - echo 'a first command'
             - echo 'a second command'
 
+A real life example: applying a patch
+
+.. code-block:: yaml
+
+    ./odoo:
+        remotes:
+        oca: https://github.com/OCA/OCB.git
+        acsone: git@github.com/acsone/OCB.git
+        merges:
+            - oca 9.0
+        target: acsone aggregated_branch_name
+        shell_command_after:
+            - git am "$(git format-patch -1 XXXXXX -o ../patches)"
 
 Command line Usage
 ==================


### PR DESCRIPTION
Current result w/ README example:
```
expected <block end>, but found '<block mapping start>'
  in "<string>", line 43, column 5:
        shell_command_after:
        ^
```
This is fixed and I added an example on how to apply a patch (just tested w/ latest odoo sec patch).