### PR TITLE
Optional merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# jetbrain solutions
+/.idea/

--- a/README.rst
+++ b/README.rst
@@ -243,6 +243,7 @@ Contributors
 * Jairo Llopis (Tecnativa_)
 * Stéphane Bidoul (ACSONE_)
 * Dave Lasley (LasLabs_)
+* Jordi Riera
 
 .. _ACSONE: https://www.acsone.eu
 .. _Tecnativa: https://www.tecnativa.com

--- a/git_aggregator/config.py
+++ b/git_aggregator/config.py
@@ -83,8 +83,8 @@ def get_repos(config):
                 raise ConfigException(
                     '%s: You should at least define one merge.' % directory)
         else:
-            raise ConfigException(
-                '%s: merges is not defined.' % directory)
+            repo_dict['merges'] = []
+
         # Only fetch required remotes by default
         repo_dict["fetch_all"] = repo_data.get("fetch_all", False)
         if isinstance(repo_dict["fetch_all"], string_types):

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -163,29 +163,30 @@ class Repo(object):
         If the target_dir doesn't exist, create an empty git repo otherwise
         clean it, add all remotes , and merge all merges.
         """
-        logger.info('Start aggregation of %s', self.cwd)
-        target_dir = self.cwd
+        if self.merges:
+            logger.info('Start aggregation of %s', self.cwd)
+            target_dir = self.cwd
 
-        with working_directory_keeper:
-            is_new = not os.path.exists(target_dir)
-            if is_new:
-                self.init_repository(target_dir)
+            with working_directory_keeper:
+                is_new = not os.path.exists(target_dir)
+                if is_new:
+                    self.init_repository(target_dir)
 
-            os.chdir(target_dir)
-            self._switch_to_branch(self.target['branch'])
-            for r in self.remotes:
-                self._set_remote(**r)
-            self.fetch()
-            merges = self.merges
-            if not is_new:
-                # reset to the first merge
-                origin = merges[0]
-                merges = merges[1:]
-                self._reset_to(origin["remote"], origin["ref"])
-            for merge in merges:
-                self._merge(merge)
-            self._execute_shell_command_after()
-        logger.info('End aggregation of %s', self.cwd)
+                os.chdir(target_dir)
+                self._switch_to_branch(self.target['branch'])
+                for r in self.remotes:
+                    self._set_remote(**r)
+                self.fetch()
+                merges = self.merges
+                if not is_new:
+                    # reset to the first merge
+                    origin = merges[0]
+                    merges = merges[1:]
+                    self._reset_to(origin["remote"], origin["ref"])
+                for merge in merges:
+                    self._merge(merge)
+                self._execute_shell_command_after()
+            logger.info('End aggregation of %s', self.cwd)
 
     def init_repository(self, target_dir):
         logger.info('Init empty git repository in %s', target_dir)

--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,5 @@ setuptools.setup(
     entry_points=dict(
         console_scripts=['gitaggregate=git_aggregator.main:main']),
     test_suite='tests',
+    tests_require=['mock']
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,19 +174,18 @@ class TestConfig(unittest.TestCase):
             ex.exception.args[0],
             '/product_attribute: No url defined for remote oca.')
 
-    def test_load_merges_exception(self):
+    def test_no_merges(self):
+        """When there is no merge given in the config, it is then exported as empty list."""
         config_yaml = """
 /product_attribute:
     remotes:
         oca: https://github.com/OCA/product-attribute.git
     target: oca aggregated_branch
 """
-        with self.assertRaises(ConfigException) as ex:
-            config.get_repos(self._parse_config(config_yaml))
-        self.assertEquals(
-            ex.exception.args[0],
-            '/product_attribute: merges is not defined.')
+        repos = config.get_repos(self._parse_config(config_yaml))
+        self.assertEquals(repos[0]['shell_command_after'], [])
 
+    def test_load_merges_exception(self):
         config_yaml = """
 /product_attribute:
     remotes:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -175,7 +175,9 @@ class TestConfig(unittest.TestCase):
             '/product_attribute: No url defined for remote oca.')
 
     def test_no_merges(self):
-        """When there is no merge given in the config, it is then exported as empty list."""
+        """When there is no merge given in the config,
+        then it is exported as empty list.
+        """
         config_yaml = """
 /product_attribute:
     remotes:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -121,7 +121,9 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(last_rev, self.commit_1_sha)
 
     def test_no_merge(self):
-        """When the list of merges is empty, the aggregate runs but no merge are proceeded."""
+        """When the list of merges is empty,
+        then the aggregate runs but no merge are proceeded.
+        """
         remotes = [{
             'name': 'r1',
             'url': self.url_remote1

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -7,6 +7,9 @@ import os
 import shutil
 import unittest
 import subprocess
+
+from mock import mock
+
 try:
     # Py 2
     from urlparse import urljoin
@@ -116,6 +119,22 @@ class TestRepo(unittest.TestCase):
         repo.aggregate()
         last_rev = git_get_last_rev(self.cwd)
         self.assertEqual(last_rev, self.commit_1_sha)
+
+    def test_no_merge(self):
+        """When the list of merges is empty, the aggregate runs but no merge are proceeded."""
+        remotes = [{
+            'name': 'r1',
+            'url': self.url_remote1
+        }]
+        merges = []
+        target = {
+            'remote': 'r1',
+            'branch': 'agg1'
+        }
+        repo = Repo(self.cwd, remotes, merges, target)
+        with mock.patch.object(Repo, '_merge') as mock_merge:
+            repo.aggregate()
+            self.assertEqual(0, mock_merge.call_count)
 
     def test_simple_merge(self):
         remotes = [{


### PR DESCRIPTION
Put the `merges` keyword as optional in the config file.
It allows the case where we want to only fetch a repository without to merge anything.

I don't know if it is by design though

PS: I need to work on the tests.. 