### PR TITLE
[IMP] Add multithreading option for aggregation (cont.)

### DIFF
--- a/git_aggregator/log.py
+++ b/git_aggregator/log.py
@@ -59,7 +59,7 @@ class LogFormatter(logging.Formatter):
         except Exception as e:
             record.message = "Bad message (%r): %r" % (e, record.__dict__)
 
-        date_format = '%H:%m:%S'
+        date_format = '%H:%M:%S'
         record.asctime = time.strftime(
             date_format, self.converter(record.created)
         )

--- a/git_aggregator/log.py
+++ b/git_aggregator/log.py
@@ -40,8 +40,13 @@ def default_log_template(self, record):
         '%(name)s',
         Fore.RESET, Style.RESET_ALL, ' '
     ]
+    threadName = [
+        ' ', Fore.BLUE, Style.DIM, Style.BRIGHT,
+        '%(threadName)s ',
+        Fore.RESET, Style.RESET_ALL, ' '
+    ]
 
-    tpl = "".join(reset + levelname + asctime + name + reset)
+    tpl = "".join(reset + levelname + asctime + name + threadName + reset)
 
     return tpl
 
@@ -93,6 +98,11 @@ def debug_log_template(self, record):
         '%(name)s',
         Fore.RESET, Style.RESET_ALL, ' '
     ]
+    threadName = [
+        ' ', Fore.BLUE, Style.DIM, Style.BRIGHT,
+        '%(threadName)s ',
+        Fore.RESET, Style.RESET_ALL, ' '
+    ]
     module_funcName = [
         Fore.GREEN, Style.BRIGHT,
         '%(module)s.%(funcName)s()'
@@ -103,7 +113,8 @@ def debug_log_template(self, record):
     ]
 
     tpl = ''.join(
-        reset + levelname + asctime + name + module_funcName + lineno + reset
+        reset + levelname + asctime + name + threadName + module_funcName +
+        lineno + reset
     )
 
     return tpl

--- a/git_aggregator/main.py
+++ b/git_aggregator/main.py
@@ -108,7 +108,7 @@ def get_parser():
     )
 
     main_parser.add_argument(
-        '--jobs',
+        '-j', '--jobs',
         dest='jobs',
         default=1,
         type=int,

--- a/git_aggregator/utils.py
+++ b/git_aggregator/utils.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class WorkingDirectoryKeeper(object):
+class WorkingDirectoryKeeper(object):  # DEPRECATED
     """A context manager to get back the working directory as it was before.
     If you want to stack working directory keepers, you need a new instance
     for each stage.
@@ -24,6 +24,3 @@ class WorkingDirectoryKeeper(object):
     def __exit__(self, *exc_args):
         os.chdir(self.wd)
         self.active = False
-
-
-working_directory_keeper = WorkingDirectoryKeeper()

--- a/git_aggregator/utils.py
+++ b/git_aggregator/utils.py
@@ -27,6 +27,9 @@ class WorkingDirectoryKeeper(object):  # DEPRECATED
         self.active = False
 
 
+working_directory_keeper = WorkingDirectoryKeeper()
+
+
 class ThreadNameKeeper(object):
     """A contect manager to get back the thread name as it was before. It
     is meant to be used when modifying the 'MainThread' tread.

--- a/git_aggregator/utils.py
+++ b/git_aggregator/utils.py
@@ -3,6 +3,7 @@
 # © ANYBOX https://github.com/anybox/anybox.recipe.odoo
 # License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
 import os
+import threading
 import logging
 logger = logging.getLogger(__name__)
 
@@ -24,3 +25,15 @@ class WorkingDirectoryKeeper(object):  # DEPRECATED
     def __exit__(self, *exc_args):
         os.chdir(self.wd)
         self.active = False
+
+
+class ThreadNameKeeper(object):
+    """A contect manager to get back the thread name as it was before. It
+    is meant to be used when modifying the 'MainThread' tread.
+    """
+
+    def __enter__(self):
+        self._name = threading.current_thread().name
+
+    def __exit__(self, *exc_args):
+        threading.current_thread().name = self._name

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# License AGPLv3 (http://www.gnu.org/licenses/agpl-3.0-standalone.html)
+
+import logging
+import threading
+import unittest
+
+from git_aggregator import main
+from git_aggregator.utils import ThreadNameKeeper
+
+logger = logging.getLogger(__name__)
+
+
+def reset_logger():
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+
+
+class TestLog(unittest.TestCase):
+
+    def setUp(self):
+        """ Setup """
+        super(TestLog, self).setUp()
+        reset_logger()
+
+    def test_info(self):
+        """ Test log.LogFormatter. """
+        main.setup_logger(logger, level=logging.INFO)
+        # self._suite = unittest.TestLoader().loadTestsFromName(
+        #     'tests.test_repo.TestRepo.test_multithreading')
+        # unittest.TextTestRunner(verbosity=0).run(self._suite)
+        logger.debug('This message SHOULD NOT be visible.')
+        logger.info('Message from MainThread.')
+        with ThreadNameKeeper():
+            name = threading.current_thread().name = 'repo_name'
+            logger.info('Message from %s.', name)
+        logger.info('Hello again from MainThread.')
+
+    def test_debug(self):
+        """ Test log.DebugLogFormatter. """
+        main.setup_logger(logger, level=logging.DEBUG)
+        logger.debug('This message SHOULD be visible.')
+        logger.info('Message from MainThread.')
+        with ThreadNameKeeper():
+            name = threading.current_thread().name = 'repo_name'
+            logger.info('Message from %s.', name)
+        logger.info('Hello again from MainThread.')
+
+    def test_colors(self):
+        """ Test log.LEVEL_COLORS. """
+        main.setup_logger(logger, level=logging.DEBUG)
+        logger.debug('Color: Fore.BLUE')
+        logger.info('Color: Fore.GREEN')
+        logger.warning('Color: Fore.YELLOW')
+        logger.error('Color: Fore.RED')
+        logger.critical('Color: Fore.RED')


### PR DESCRIPTION
(Cont. from https://github.com/acsone/git-aggregator/pull/16)

**[REF]** Use `cwd` in system calls instead of the `WorkingDirectoryKeeper`, changing the process CWD is not thread-safe as it is shared among all threads.
**[REF]** `multithreading` + `queue` instead of a `multiprocessing.Pool`: better I/O operations, better `Exception`s management, prevent logs from getting messed up...
**[IMP]** Show current repository name in logs (useful when using multiple threads).
**[FIX]** Log date was using `%m` (zero-padded month) instead of `%M` (zero-padded minutes).
**[REF]** Rename `--pool-count` to `-j`/`--jobs`, to mimic `git fetch` params.
**[ADD]** Multithreading tests.