### PR TITLE
Let Kaptan pick the handler of it's own choice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,8 @@ To work around API limitation, you must first generate a
 Changes
 =======
 
+* Mimic Kaptan's behavior of resolving handler by extension (#22)
+
 1.2.1 (July, 12, 2018)
 ----------------------
 

--- a/git_aggregator/config.py
+++ b/git_aggregator/config.py
@@ -134,8 +134,8 @@ def load_config(config, expand_env=False):
     if not os.path.exists(config):
         raise ConfigException('Unable to find configuration file: %s' % config)
 
-    fExt = os.path.splitext(config)[-1]
-    conf = kaptan.Kaptan(handler=fExt.lstrip('.'))
+    file_extension = os.path.splitext(config)[1][1:]
+    conf = kaptan.Kaptan(handler=kaptan.HANDLER_EXT.get(file_extension))
 
     if expand_env:
         with open(config, 'r') as file_handler:


### PR DESCRIPTION
Since file handler name is being provided directly to `Kaptan` instance, it doesn't try to guess it. Although, it is able to do pretty much the same job of taking the extension from a filename and then using an appropriate file handler to parse stuff - you don't need to be so explicit here :)

As a fancy side-effect - for me, git-aggregator has finally started to parse `.yml` files properly. I'm aware that there's #14 in a `master` already, but that approach doesn't really solve the issue outside of the autocompletion scope.

Kaptan tries to guess the handler [here](https://github.com/emre/kaptan/blob/8f5406517a3eca2f473cea3028ff4ddbdf917fbd/kaptan/__init__.py#L70-L75)
Currently, providing a `handler='yml'` handler directly ends up in a `KeyError` [here](https://github.com/emre/kaptan/blob/8f5406517a3eca2f473cea3028ff4ddbdf917fbd/kaptan/__init__.py#L38-L44)