### PR TITLE
Do not die if repos.yaml is empty

### DIFF
--- a/git_aggregator/config.py
+++ b/git_aggregator/config.py
@@ -143,4 +143,4 @@ def load_config(config, expand_env=False):
             config = config.substitute(os.environ)
 
     conf.import_config(config)
-    return get_repos(conf.export('dict'))
+    return get_repos(conf.export('dict') or {})


### PR DESCRIPTION
Before this patch, you'd get this error in such case:

    Traceback (most recent call last):
    File "/usr/local/bin/gitaggregate", line 11, in <module>
        sys.exit(main())
    File "/usr/local/lib/python3.5/dist-packages/git_aggregator/main.py", line 131, in main
        run(args)
    File "/usr/local/lib/python3.5/dist-packages/git_aggregator/main.py", line 165, in run
        repos = load_config(args.config, args.expand_env)
    File "/usr/local/lib/python3.5/dist-packages/git_aggregator/config.py", line 146, in load_config
        return get_repos(conf.export('dict'))
    File "/usr/local/lib/python3.5/dist-packages/git_aggregator/config.py", line 24, in get_repos
        for directory, repo_data in config.items():
    AttributeError: 'NoneType' object has no attribute 'items'