### PR TITLE
Fix wrong PR URL in logs and log closed PR labels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,12 @@ To work around API limitation, you must first generate a
 Changes
 =======
 
+1.7.0 (August 14, 2019)
+-----------------------
+
+* Fix a bug in ``--show-all-prs``, which was printing a wrong PR URL.
+* Display PR labels too in ``--show-all-prs``.
+
 1.6.0 (March 04, 2019)
 ----------------------
 
@@ -276,7 +282,7 @@ Contributors
 * Cristian Moncho
 * Simone Orsi (camptocamp_)
 * Artem Kostyuk
- 
+
 .. _ACSONE: https://www.acsone.eu
 .. _Tecnativa: https://www.tecnativa.com
 .. _camptocamp: https://www.camptocamp.com

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -351,6 +351,9 @@ class Repo(object):
             rj = r.json()
             pr_info['state'] = rj.get('state')
             pr_info['url'] = rj.get('html_url')
+            pr_info['labels'] = ", ".join(
+                label['name'] for label in rj.get('labels')
+            )
             pr_info['merged'] = (
                 not rj.get('merged') and 'not ' or ''
             ) + 'merged'
@@ -362,7 +365,8 @@ class Repo(object):
         all_prs = self.collect_prs_info()
         for pr_info in all_prs.get('closed', []):
             logger.info(
-                '{url} in state {state} ({merged})'.format(**pr_info)
+                '{url} in state {state} ({merged}; labels: {labels})'
+                .format(**pr_info)
             )
 
     def show_all_prs(self):

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -340,7 +340,6 @@ class Repo(object):
                 'pr': pull_mo.group('pr'),
             }
             pr_info['path'] = '{owner}/{repo}/pulls/{pr}'.format(**pr_info)
-            pr_info['url'] = 'https://github.com/{path}'.format(**pr_info)
             pr_info['shortcut'] = '{owner}/{repo}#{pr}'.format(**pr_info)
             r = self._github_api_get('/repos/{path}'.format(**pr_info))
             if r.status_code != 200:
@@ -349,9 +348,11 @@ class Repo(object):
                     'Reason: {r.status_code} {r.reason}'.format(r=r, **pr_info)
                 )
                 continue
-            pr_info['state'] = r.json().get('state')
+            rj = r.json()
+            pr_info['state'] = rj.get('state')
+            pr_info['url'] = rj.get('html_url')
             pr_info['merged'] = (
-                not r.json().get('merged') and 'not ' or ''
+                not rj.get('merged') and 'not ' or ''
             ) + 'merged'
             all_prs.setdefault(pr_info['state'], []).append(pr_info)
         return all_prs


### PR DESCRIPTION
Before this patch, an URL with `/pulls/` appeared in the logs, when the correct one is with `/pull/` instead.

It turns out the GitHub API returns the browsable URL in the response, so I use that one instead.

Also, bots tend to mark PRs as closed instead of merged, but add some label that indicates such state. Let's log labels to have that information at hand.