### PR TITLE
[ADD] show-status command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,6 +204,26 @@ To work around API limitation, you must first generate a
 
 .. _Github API token: https://github.com/settings/tokens
 
+Show local status
+=================
+
+gitaggregate allows you to log all the local changes with the command
+``show-status``
+
+.. code-block:: bash
+
+   $ gitaggregate show-status -c repos.yaml
+
+Result sample
+
+.. code-block:: bash
+
+    (INFO) [11:04:04] git_aggregator.repo  pos   Repo /opt/grap_dev/grap-odoo-env-8.0/src/pos: 3 changes found.
+        R  pos_margin/__openerp__.py -> pos_margin/__manifest__.py
+        R  pos_order_load/__openerp__.py -> pos_order_load/__manifest__.py
+        ?? test/
+
+
 Changes
 =======
 

--- a/git_aggregator/main.py
+++ b/git_aggregator/main.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 _LOG_LEVEL_STRINGS = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
 
+_COMMAND_LIST = ['aggregate', 'show-closed-prs', 'show-all-prs', 'show-status']
+
 
 def _log_level_string_to_int(log_level_string):
     if log_level_string not in _LOG_LEVEL_STRINGS:
@@ -134,6 +136,7 @@ def get_parser():
              '              a github.com remote and a\n'
              '              refs/pull/NNN/head ref in the merge section.\n'
              'show-closed-prs: show pull requests that are not open anymore.\n'
+             'show-status: show status in each repositories.\n'
     )
 
     return main_parser
@@ -153,9 +156,7 @@ def main():
     )
 
     try:
-        if args.config and \
-                args.command in \
-                ('aggregate', 'show-closed-prs', 'show-all-prs'):
+        if args.config and args.command in _COMMAND_LIST:
             run(args)
         else:
             parser.print_help()
@@ -208,6 +209,8 @@ def aggregate_repo(repo, args, sem, err_queue):
             repo.show_closed_prs()
         elif args.command == 'show-all-prs':
             repo.show_all_prs()
+        elif args.command == 'show-status':
+            repo.show_status()
     except Exception:
         err_queue.put_nowait(sys.exc_info())
     finally:

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -380,3 +380,20 @@ class Repo(object):
                 logger.info(
                     '{url} in state {state} ({merged})'.format(**pr_info)
                 )
+
+    def show_status(self):
+        """Log status in each repository, if there are local changes"""
+        status = self.log_call(
+            ['git', 'status', '--short'],
+            callwith=subprocess.check_output,
+            cwd=self.cwd
+        )
+        if status:
+            logger.info(
+                "{folder} : {qty} local change(s) found.\n"
+                "{status}".format(
+                    folder=self.cwd,
+                    qty=len(status.splitlines()),
+                    status=status,
+                ))
+        return status


### PR DESCRIPTION
Hi all. 

first, thanks for this great tool. 

I propose an addition to git-aggregator lib: the command ``show-status``.
Basically, gitaggregate will call ``git status  -short`` for all the listed repositories and display result, if there are some local changes.

Call Sample: 

    gitaggregate show-status -c repos.yaml

Result Sample: 

    (INFO) [11:04:04] git_aggregator.repo  pos   Repo /opt/grap_dev/grap-odoo-env-8.0/src/pos: 3 changes found.
        R  pos_margin/__openerp__.py -> pos_margin/__manifest__.py
        R  pos_order_load/__openerp__.py -> pos_order_load/__manifest__.py
        ?? test/