### PR TITLE
[IMP] DRY definition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Create a ``repos.yaml`` or ``repos.yml`` file:
         fetch_all:
             - oca
 
+    ./web: https://github.com/OCA/web.git 12.0
+
 Environment variables inside of this file will be expanded if the proper option is selected.
 
 Fetching only required branches

--- a/git_aggregator/config.py
+++ b/git_aggregator/config.py
@@ -27,10 +27,27 @@ def get_repos(config, force=False):
             directory = os.path.abspath(directory)
         repo_dict = {
             'cwd': directory,
-            'defaults': repo_data.get('defaults', dict()),
             'force': force,
+            'defaults': dict(),
+            'fetch_all': False,
+            'shell_command_after': [],
         }
         remote_names = set()
+        # Handle DRY format
+        if isinstance(repo_data, string_types):
+            parts = repo_data.split(' ')
+            if len(parts) != 2:
+                raise ConfigException(
+                    '%s: Repository must be formatted as '
+                    '"url ref".' % directory)
+            repo_dict['remotes'] = [{'name': 'origin', 'url': parts[0]}]
+            repo_dict['merges'] = [{'remote': 'origin', 'ref': parts[1]}]
+            repo_dict['target'] = {'remote': 'origin', 'branch': parts[1]}
+            repo_list.append(repo_dict)
+            continue
+        # full format
+        if 'defaults' in repo_data:
+            repo_dict['defaults'] = repo_data.get('defaults', dict())
         if 'remotes' in repo_data:
             repo_dict['remotes'] = []
             remotes_data = repo_data['remotes'] or {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,6 +136,24 @@ class TestConfig(unittest.TestCase):
         repos = config.get_repos(self._parse_config(config_yaml))
         self.assertEquals(repos[0]['shell_command_after'], ['ls', 'echo'])
 
+    def test_load_dry(self):
+        config_yaml = """
+/product_attribute: https://github.com/OCA/product-attribute.git 12.0
+"""
+        repos = config.get_repos(self._parse_config(config_yaml))
+        self.assertEquals(repos[0]['remotes'], [{
+            'name': 'origin',
+            'url': 'https://github.com/OCA/product-attribute.git'}])
+        self.assertEquals(repos[0]['merges'], [{
+            'remote': 'origin',
+            'ref': '12.0'}])
+        self.assertEquals(repos[0]['target'], {
+            'remote': 'origin',
+            'branch': '12.0'})
+        self.assertFalse(repos[0]['fetch_all'])
+        self.assertFalse(repos[0]['shell_command_after'])
+        self.assertFalse(repos[0]['defaults'])
+
     def test_load_remotes_exception(self):
         config_yaml = """
 /product_attribute:


### PR DESCRIPTION
Hi!

Thanks so much for this amazing tool. It's becoming a must-have for most of us ^^

Not sure if this is within the scope, but personally I'm using this tool not just for mixing refs, but also to organize the repositories to deploy.

With this PR it's now possible to specify a DRY repository definition that will result in something similar to a simple clone.

```yaml
web: https://github.com/OCA/web.git 8.0

server-tools: https://github.com/OCA/server-tools.git 8.0

product_attribute:
    remotes:
        oca: https://github.com/OCA/product-attribute.git
        acsone: git+ssh://git@github.com/acsone/product-attribute.git
    merges:
        - oca 8.0
        - oca refs/pull/105/head
        - oca refs/pull/106/head
    target: acsone aggregated_branch_name
```