### PR TITLE
[IMP] --with-default argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,12 @@ the ``dict`` alternate construction. If you need to disable a default in
                 ref: refs/pull/14859/head
         target: acsone 9.0
 
+It's also possible to set default values to all repositories
+
+.. code-block:: bash
+
+    $ gitaggregate -c repos.yaml --with-default depth:1
+
 Remember that you need to fetch at least the common ancestor of all merges for
 it to succeed.
 


### PR DESCRIPTION
Thanks again for this tool :)

This PR adds a new argument to define default arguments for fetching.

Basically, when running `gitaggregate -c repos.yml --with-default depth:1`, it'll apply a default `depth` value for all repositories, unless it has an explicit value on the config file.

`depth: False` also works as an explicit config value
