### PR TITLE
[IMP] Get env variables from file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,21 @@ Expand environment variables inside of the configuration file when loading:
 
     $ gitaggregate -c repos.yaml --expand-env
 
+The variable in the configuration file can be specified in one of the following ways:
+
+    - $VARIABLE
+    - ${VARIABLE}
+
+For mor info, see the Python's string.Template documentation.
+
+Use additional variables from file while expanding:
+
+.. code-block:: bash
+
+    $ gitaggregate -c repos.yaml --expand-env --env-file .env
+
+The env file should contain `VAR=value` lines. Lines starting with # are ignored.
+
 You can also aggregate and automatically push the result to the target:
 
 .. code-block:: bash

--- a/git_aggregator/main.py
+++ b/git_aggregator/main.py
@@ -233,7 +233,8 @@ def run(args):
     """Load YAML and JSON configs and run the command specified
     in args.command"""
 
-    repos = load_config(args.config, args.expand_env, args.env_file, args.force)
+    repos = load_config(
+        args.config, args.expand_env, args.env_file, args.force)
 
     jobs = max(args.jobs, 1)
     threads = []

--- a/git_aggregator/main.py
+++ b/git_aggregator/main.py
@@ -108,6 +108,12 @@ def get_parser():
         help='Expand environment variables in configuration file',
     )
     main_parser.add_argument(
+        '--env-file',
+        dest='env_file',
+        default=None,
+        help='Path to file with variables to be added to the environment',
+    )
+    main_parser.add_argument(
         '-f', '--force',
         dest='force',
         default=False,
@@ -183,7 +189,7 @@ def match_dir(cwd, dirmatch=None):
 def load_aggregate(args):
     """Load YAML and JSON configs and begin creating / updating , aggregating
     and pushing the repos (deprecated in favor or run())"""
-    repos = load_config(args.config, args.expand_env)
+    repos = load_config(args.config, args.expand_env, args.env_file)
     dirmatch = args.dirmatch
     for repo_dict in repos:
         r = Repo(**repo_dict)
@@ -227,7 +233,7 @@ def run(args):
     """Load YAML and JSON configs and run the command specified
     in args.command"""
 
-    repos = load_config(args.config, args.expand_env, args.force)
+    repos = load_config(args.config, args.expand_env, args.env_file, args.force)
 
     jobs = max(args.jobs, 1)
     threads = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -356,7 +356,7 @@ class TestConfig(unittest.TestCase):
             """
         vars_env = """
             # comment
-            
+
             TEST_REPO=to be overridden by environ
             TEST_FOLDER = /test
             """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -343,6 +343,44 @@ class TestConfig(unittest.TestCase):
             remotes[0]['url'], os.environ['TEST_REPO']
         )
 
+    def test_import_config_expand_env_from_file(self):
+        """ It should expand the config with variables form file. """
+        os.environ['TEST_REPO'] = 'https://github.com/test/test.git'
+        data_yaml = """
+            ${TEST_FOLDER}:
+                remotes:
+                    oca: $TEST_REPO
+                merges:
+                    - oca 8.0
+                target: oca aggregated_branch_name
+            """
+        vars_env = """
+            # comment
+            
+            TEST_REPO=to be overridden by environ
+            TEST_FOLDER = /test
+            """
+
+        _, env_path = tempfile.mkstemp(suffix='.env')
+        try:
+            with open(env_path, 'w') as env_file:
+                env_file.write(vars_env)
+                _, config_path = tempfile.mkstemp(suffix='.yaml')
+            with open(config_path, 'w') as config_file:
+                config_file.write(data_yaml)
+            repos = config.load_config(config_file.name, True, env_file.name)
+        finally:
+            if os.path.exists(env_path):
+                os.remove(env_path)
+            if os.path.exists(config_path):
+                os.remove(config_path)
+
+        self.assertEqual(repos[0]['cwd'], '/test')
+        remotes = repos[0]['remotes']
+        self.assertEqual(
+            remotes[0]['url'], os.environ['TEST_REPO']
+        )
+
     def test_fetch_all_string(self):
         config_yaml = """
             ./test:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -351,6 +351,7 @@ class TestRepo(unittest.TestCase):
             dirmatch=None,
             do_push=False,
             expand_env=False,
+            env_file=None,
             force=False,
         )
 


### PR DESCRIPTION
This PR extends the variables substitution in the config file allowing to specify additional variables in a file. The variables from the file are with lesser priority than the environment variables. 

The feature is useful in a docker-compose context for example where the local user configuration can be extracted in a .env file. 

A more flexible implementation may be done by using the python-dotenv package but I preferred not to add additional dependencies for such a small feature. 