### PR TITLE
Make the `target` section optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,6 @@ Create a ``repos.yaml`` or ``repos.yml`` file:
             - oca 8.0
             - oca refs/pull/105/head
             - oca refs/pull/106/head
-        target: acsone aggregated_branch_name
 
     ./connector-interfaces:
         remotes:
@@ -181,7 +180,8 @@ Use additional variables from file while expanding:
 
 The env file should contain `VAR=value` lines. Lines starting with # are ignored.
 
-You can also aggregate and automatically push the result to the target:
+You can also aggregate and automatically push the result to the target, if the
+``target`` option is configured:
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ Create a ``repos.yaml`` or ``repos.yml`` file:
 
 Environment variables inside of this file will be expanded if the proper option is selected.
 
+All the ``merges`` are combined into a single branch. By default this branch is called ``_git_aggregated`` but another name may be given in the ``target`` section.
+
 Fetching only required branches
 -------------------------------
 

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -208,6 +208,10 @@ class Repo(object):
     def push(self):
         remote = self.target['remote']
         branch = self.target['branch']
+        if remote is None:
+            raise GitAggregatorException(
+                "Cannot push %s, no target remote configured" % branch
+            )
         logger.info("Push %s to %s", branch, remote)
         self.log_call(['git', 'push', '-f', remote, branch], cwd=self.cwd)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -252,26 +252,14 @@ class TestConfig(unittest.TestCase):
         oca: https://github.com/OCA/product-attribute.git
     merges:
         - oca 8.0
-"""
-        with self.assertRaises(ConfigException) as ex:
-            config.get_repos(self._parse_config(config_yaml))
-        self.assertEquals(ex.exception.args[0],
-                          '/product_attribute: No target defined.')
-
-        config_yaml = """
-/product_attribute:
-    remotes:
-        oca: https://github.com/OCA/product-attribute.git
-    merges:
-        - oca 8.0
-    target:
+    target: oca 8.0 extra_arg
 """
         with self.assertRaises(ConfigException) as ex:
             config.get_repos(self._parse_config(config_yaml))
         self.assertEquals(
             ex.exception.args[0],
             '/product_attribute: Target must be formatted as '
-            '"remote_name branch_name"')
+            '"[remote_name] branch_name"')
 
         config_yaml = """
 /product_attribute:
@@ -286,6 +274,32 @@ class TestConfig(unittest.TestCase):
         self.assertEquals(
             ex.exception.args[0],
             '/product_attribute: Target remote oba not defined in remotes.')
+
+    def test_target_defaults(self):
+        config_yaml = """
+/product_attribute:
+    remotes:
+        oca: https://github.com/OCA/product-attribute.git
+    merges:
+        - oca 8.0
+    target: 8.0
+"""
+        repos = config.get_repos(self._parse_config(config_yaml))
+        self.assertDictEqual(
+            repos[0]["target"], {"branch": "8.0", "remote": None}
+        )
+
+        config_yaml = """
+/product_attribute:
+    remotes:
+        oca: https://github.com/OCA/product-attribute.git
+    merges:
+        - oca 8.0
+"""
+        repos = config.get_repos(self._parse_config(config_yaml))
+        self.assertDictEqual(
+            repos[0]["target"], {"branch": "_git_aggregated", "remote": None}
+        )
 
     def test_import_config__not_found(self):
         with self.assertRaises(ConfigException) as exc:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -150,6 +150,34 @@ class TestRepo(unittest.TestCase):
         self.assertEquals(rtype, 'branch')
         self.assertTrue(sha)
 
+    def test_push_missing_remote(self):
+        remotes = [{
+            'name': 'r1',
+            'url': self.url_remote1
+        }, {
+            'name': 'r2',
+            'url': self.url_remote2
+        }]
+        merges = [{
+            'remote': 'r1',
+            'ref': 'tag1'
+        }, {
+            'remote': 'r2',
+            'ref': self.commit_3_sha
+        }]
+        target = {
+            'remote': None,
+            'branch': 'agg'
+        }
+        repo = Repo(self.cwd, remotes, merges, target, fetch_all=True)
+        repo.aggregate()
+        with self.assertRaises(exception.GitAggregatorException) as ex:
+            repo.push()
+        self.assertEquals(
+            ex.exception.args[0],
+            "Cannot push agg, no target remote configured"
+        )
+
     def test_update_aggregate(self):
         # in this test
         # * we'll aggregate a first time r1 master with r2


### PR DESCRIPTION
This makes it possible to use the `target` configuration without a remote (in which case pushing will be impossible) and to leave it out completely (in which case a branch called `_git_aggregated` will be used for aggregation).

Resolves #30.