### PR TITLE
Do not exit with success on KeyboardInterrupt

### DIFF
--- a/git_aggregator/main.py
+++ b/git_aggregator/main.py
@@ -175,7 +175,7 @@ def main():
     try:
         run(args)
     except KeyboardInterrupt:
-        pass
+        return 1
 
 
 def match_dir(cwd, dirmatch=None):


### PR DESCRIPTION
`gitaggregate` catches `KeyboardInterrupt`, I'm guessing to avoid an ugly traceback.

But we run `gitaggregate` in a shell script (with `set -e`), and interrupting it should also stop the script. That only works if it exits with an error code.