### PR TITLE
Migrate Github API authentication to new spec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,11 @@ To work around API limitation, you must first generate a
 Changes
 =======
 
+2.1 (August 26, 2021)
+---------------------
+
+* Migrate Github API authentication to new spec (https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/)
+
 2.0 (August 17, 2021)
 ---------------------
 

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -314,9 +314,10 @@ class Repo(object):
     def _github_api_get(self, path):
         url = 'https://api.github.com' + path
         token = os.environ.get('GITHUB_TOKEN')
+        headers = None
         if token:
-            url += '?access_token=' + token
-        return requests.get(url)
+            headers = {'Authorization': 'token %s' % token}
+        return requests.get(url, headers=headers)
 
     def collect_prs_info(self):
         """Collect all pending merge PRs info.


### PR DESCRIPTION
Starting on September 8 2021, it will no longer be possible to authenticate API requests passing the token as a query parameter.
Instead, it should be passed in the header.
See https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

@Tecnativa
TT31500

ping @Yajo @sbidoul 