### PR TITLE
Change log message for updating remotes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,12 @@ To work around API limitation, you must first generate a
 Changes
 =======
 
+2.1.1 (October 20, 2021)
+---------------------
+
+* When updating remotes the log message now states ``Updating remote`` instead of ``Remote remote``
+
+
 2.1 (August 26, 2021)
 ---------------------
 

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -306,7 +306,7 @@ class Repo(object):
             logger.info('Adding remote %s <%s>', name, url)
             self.log_call(['git', 'remote', 'add', name, url], cwd=self.cwd)
         else:
-            logger.info('Remote remote %s <%s> -> <%s>',
+            logger.info('Updating remote %s <%s> -> <%s>',
                         name, exising_url, url)
             self.log_call(['git', 'remote', 'rm', name], cwd=self.cwd)
             self.log_call(['git', 'remote', 'add', name, url], cwd=self.cwd)


### PR DESCRIPTION
Remote remote odoo <https://gitlab.example.com/odoo/odoo.git> -> <https://github.com/odoo/odoo.git>
becomes
Updating remote odoo <https://gitlab.example.com/odoo/odoo.git> -> <https://github.com/odoo/odoo.git>

Info @wt-io-it