### PR TITLE
Set Git config in CI following warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           git config --global user.name "test"
           git config --global user.email "test.test@test.com"
+          git config --global init.defaultBranch master
+          git config --global pull.rebase false
       - name: "Run tox targets for ${{ matrix.python-version }}"
         run: |
           python -m tox


### PR DESCRIPTION
Fixes #58

Also hitting the `defaultBranch` because it might do the exact same thing.