### PR TITLE
Add --no-rebase to git pull

### DIFF
--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -262,7 +262,7 @@ class Repo(object):
 
     def _merge(self, merge):
         logger.info("Pull %s, %s", merge["remote"], merge["ref"])
-        cmd = ("git", "pull")
+        cmd = ("git", "pull", "--no-rebase")
         if self.git_version >= (1, 7, 10):
             # --edit and --no-edit appear with Git 1.7.10
             # see Documentation/RelNotes/1.7.10.txt of Git


### PR DESCRIPTION
To fix tests with recent git versions which
require an explicit strategy.