### PR TITLE
ensure non-fast-forward merges

### DIFF
--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -298,7 +298,7 @@ class Repo(object):
 
     def _merge(self, merge):
         logger.info("Pull %s, %s", merge["remote"], merge["ref"])
-        cmd = ("git", "pull", "--no-rebase")
+        cmd = ("git", "pull", "--no-ff", "--no-rebase")
         if self.git_version >= (1, 7, 10):
             # --edit and --no-edit appear with Git 1.7.10
             # see Documentation/RelNotes/1.7.10.txt of Git


### PR DESCRIPTION
avoid errors when git is configured with `pull.ff = only`.

re-applying #62 after revert and rebase.