### PR TITLE
Add optional tagging of target branches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ the aggregated directory.
             - echo 'a first command'
             - echo 'a second command'
 
-A real life example: applying a patch
+A real life example: applying a patch and tagging the target when pushing.
 
 .. code-block:: yaml
 
@@ -147,6 +147,7 @@ A real life example: applying a patch
         merges:
             - oca 9.0
         target: acsone aggregated_branch_name
+        tag_target: True
         shell_command_after:
             - git am "$(git format-patch -1 XXXXXX -o ../patches)"
 
@@ -185,6 +186,11 @@ The env file should contain `VAR=value` lines. Lines starting with # are ignored
 You can also aggregate and automatically push the result to the target, if the
 ``target`` option is configured:
 
+If ``tag_target`` is set to True, when pushing, the target will be tagged with the name
+of the the ``target`` branch followed by the commit sha. This is useful to ensure that
+the target commits remain reachable after force-pushing the target branch in subsequent
+git-aggregator runs.
+
 .. code-block:: bash
 
     $ gitaggregate -c repos.yaml -p
@@ -220,6 +226,11 @@ To work around API limitation, you must first generate a
 
 Changes
 =======
+
+3.1.0 (unreleased)
+------------------
+
+* Add ``tag_target`` repo configuration flag
 
 3.0.1 (2022-09-21)
 ------------------

--- a/git_aggregator/config.py
+++ b/git_aggregator/config.py
@@ -117,6 +117,7 @@ def get_repos(config, force=False):
         repo_dict['target'] = {
             'remote': remote_name,
             'branch': branch,
+            'tag': repo_data.get('tag_target', False),
         }
         commands = []
         if 'shell_command_after' in repo_data:

--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -165,6 +165,18 @@ class Repo(object):
             ret = console_to_str(ret)
         return ret
 
+    def get_sha(self, branch):
+        """Get the sha of the given branch
+        :param branch: the branch to get the sha from
+        :return: the sha of the given branch
+        """
+        return self.log_call(
+            ['git', 'rev-parse', branch],
+            cwd=self.cwd,
+            universal_newlines=True,
+            callwith=subprocess.check_output
+        ).strip()
+
     def aggregate(self):
         """ Aggregate all merges into the target branch
         If the target_dir doesn't exist, create an empty git repo otherwise
@@ -256,6 +268,11 @@ class Repo(object):
             )
         logger.info("Push %s to %s", branch, remote)
         self.log_call(['git', 'push', '-f', remote, branch], cwd=self.cwd)
+        if self.target.get('tag'):
+            tag = branch + "-" + self.get_sha(branch)
+            logger.info("Create and push tag %s to %s", tag, remote)
+            self.log_call(['git', 'tag', tag], cwd=self.cwd)
+            self.log_call(['git', 'push', remote, tag], cwd=self.cwd)
 
     def _check_status(self):
         """Check repo status and except if dirty."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,7 +49,8 @@ class TestConfig(unittest.TestCase):
              'remotes': [],
              'shell_command_after': [],
              'target': {'branch': 'aggregated_branch_name',
-                        'remote': 'acsone'}})
+                        'remote': 'acsone',
+                        'tag': False}})
         assertfn = self.assertItemsEqual if PY2 else self.assertCountEqual
         assertfn(
             remotes,
@@ -77,6 +78,7 @@ class TestConfig(unittest.TestCase):
                         remote: oca
                         ref: refs/pull/106/head
                 target: acsone aggregated_branch_name
+                tag_target: True
         """)
         repos = config.get_repos(self._parse_config(config_yaml))
         self.assertEqual(len(repos), 1)
@@ -96,7 +98,8 @@ class TestConfig(unittest.TestCase):
              'remotes': [],
              'shell_command_after': [],
              'target': {'branch': 'aggregated_branch_name',
-                        'remote': 'acsone'}})
+                        'remote': 'acsone',
+                        'tag': True}})
         assertfn = self.assertItemsEqual if PY2 else self.assertCountEqual
         assertfn(
             remotes,
@@ -286,7 +289,7 @@ class TestConfig(unittest.TestCase):
 """
         repos = config.get_repos(self._parse_config(config_yaml))
         self.assertDictEqual(
-            repos[0]["target"], {"branch": "8.0", "remote": None}
+            repos[0]["target"], {"branch": "8.0", "remote": None, "tag": False}
         )
 
         config_yaml = """
@@ -298,7 +301,9 @@ class TestConfig(unittest.TestCase):
 """
         repos = config.get_repos(self._parse_config(config_yaml))
         self.assertDictEqual(
-            repos[0]["target"], {"branch": "_git_aggregated", "remote": None}
+            repos[0]["target"], {
+                "branch": "_git_aggregated", "remote": None, "tag": False
+            }
         )
 
     def test_import_config__not_found(self):


### PR DESCRIPTION
Add a `tag_target` flag in repo configuration.

When true, gitaggregate places a tag on the head of the branch when pushing to the remote repo.

This ensures that commits remain reachable after force-pushes by subsequent git-aggregator runs.