### PR TITLE
ensure default pull fast-forward behavior

### DIFF
--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -304,7 +304,7 @@ class Repo(object):
 
     def _merge(self, merge):
         logger.info("Pull %s, %s", merge["remote"], merge["ref"])
-        cmd = ("git", "pull", "--no-rebase")
+        cmd = ("git", "pull", "--ff", "--no-rebase")
         if self.git_version >= (1, 7, 10):
             # --edit and --no-edit appear with Git 1.7.10
             # see Documentation/RelNotes/1.7.10.txt of Git


### PR DESCRIPTION
ensure default pull fast-forward behavior is used to avoid errors when git is configured to use another behavior through the `pull.ff` option.

replaces #65.