### PR TITLE
Replace kaptan with direct PyYAML SafeLoader usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,12 @@ To work around API limitation, you must first generate a
 Changes
 =======
 
+UNRELEASED
+------------------
+
+* Replace Kaptan with PyYAML.
+
+
 3.0.1 (2022-09-21)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'kaptan',
+        'PyYAML',
         'argcomplete',
         'colorama',
         'requests',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,9 @@
 import os
 import tempfile
 import unittest
-import kaptan
 from textwrap import dedent
+
+import yaml
 
 from git_aggregator import config
 from git_aggregator.exception import ConfigException
@@ -15,9 +16,11 @@ from git_aggregator._compat import PY2
 class TestConfig(unittest.TestCase):
 
     def _parse_config(self, config_str):
-        conf = kaptan.Kaptan(handler='yaml')
-        conf.import_config(config_str)
-        return conf.export('dict')
+        content = yaml.load(
+            config_str,
+            Loader=yaml.SafeLoader,
+        )
+        return content
 
     def test_load(self):
         config_yaml = """


### PR DESCRIPTION
This PR replaces the [kaptan](https://github.com/emre/kaptan) configuration parser with direct usage of PyYAML's SafeLoader class.

Why: 

* Kaptan depends on `PyYAML>=3.13,<6`, which is lower than the currently released 6.0. This can lead to dependency resolution issues.
* Kaptan is pretty much unmaintained with the last release to pypi in 2019 and the only developer who had been committing was unable to get access and deprecated it in their own projects: https://github.com/emre/kaptan/issues/176

How:

* Yaml file is read if needed, then passed as a string to PyYAML SafeLoader (this is what Kaptan is for this projects usage: https://github.com/emre/kaptan/blob/master/kaptan/handlers/yaml_handler.py#L21) 
* PyYAML is added to this project as a dependency instead of kaptan

Caveats:

* Only `.yaml` and `yml` file extensions are supported. This check can be easily removed to revert to previous filename behaviour.
* Technically the previous usage of Kaptan allowed yaml, json, pyfile, dict and ini handlers. This was not tested nor documented. If is an actual feature and needs to be maintained then this code will not suffice, and a more feature config reader would be needed (with many more tests!).
* I was not able to get all the tests to pass in my local for master branch, the same tests fail for this branch for me. I don't they are related to my changes.