### PR TITLE
Drop support for other configuration file formats than yaml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,10 @@ To work around API limitation, you must first generate a
 Changes
 =======
 
+4.0 (2023-07-22)
+----------------
+
+* [BREAKING] drop support for other configuration file formats than yaml
 * Ensure git pull is always done in fast-forward mode
 
 3.0.1 (2022-09-21)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'kaptan',
+        'PyYAML>=5',
         'argcomplete',
         'colorama',
         'requests',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,9 @@
 import os
 import tempfile
 import unittest
-import kaptan
 from textwrap import dedent
+
+import yaml
 
 from git_aggregator import config
 from git_aggregator.exception import ConfigException
@@ -15,9 +16,7 @@ from git_aggregator._compat import PY2
 class TestConfig(unittest.TestCase):
 
     def _parse_config(self, config_str):
-        conf = kaptan.Kaptan(handler='yaml')
-        conf.import_config(config_str)
-        return conf.export('dict')
+        return yaml.load(config_str, Loader=yaml.SafeLoader)
 
     def test_load(self):
         config_yaml = """


### PR DESCRIPTION
Due to the kaptan library being unmaintained.

Supersedes #72