### PR TITLE
fix: git remote: change url instead of rm / add

### DIFF
--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -350,8 +350,8 @@ class Repo(object):
         else:
             logger.info('Updating remote %s <%s> -> <%s>',
                         name, exising_url, url)
-            self.log_call(['git', 'remote', 'rm', name], cwd=self.cwd)
-            self.log_call(['git', 'remote', 'add', name, url], cwd=self.cwd)
+            self.log_call(
+                ['git', 'remote', 'set-url', name, url], cwd=self.cwd)
 
     def _github_api_get(self, path):
         url = 'https://api.github.com' + path


### PR DESCRIPTION
With some repos, there is an issue when the origin url is changed to a fork in repo.yml.

Errors look like `unable to read sha1 file of`, `index-pack failed`

It's occuring when the remote is removed (git remote rm origin) then added back with another url (git remote add origin <new url>).

With this fix, we change the url inplace. `git remote set-url origin <new url>`