### PR TITLE
[fix] target_dir may be an empty directory

### DIFF
--- a/git_aggregator/repo.py
+++ b/git_aggregator/repo.py
@@ -173,7 +173,7 @@ class Repo(object):
         logger.info('Start aggregation of %s', self.cwd)
         target_dir = self.cwd
 
-        is_new = not os.path.exists(target_dir)
+        is_new = not os.path.exists(target_dir) or os.listdir(target_dir) == []
         if is_new:
             cloned = self.init_repository(target_dir)
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -124,6 +124,28 @@ class TestRepo(unittest.TestCase):
         last_rev = git_get_last_rev(self.cwd)
         self.assertEqual(last_rev, self.commit_1_sha)
 
+    def test_empty_dir(self):
+        # ensure git clone in empty directory works
+        remotes = [{
+            'name': 'r1',
+            'url': self.url_remote1
+        }]
+        merges = [{
+            'remote': 'r1',
+            'ref': 'tag1'
+        }]
+        target = {
+            'remote': 'r1',
+            'branch': 'agg1'
+        }
+        # self.cwd should not exist yet
+        self.assertFalse(os.path.exists(self.cwd))
+        os.mkdir(self.cwd)
+        repo = Repo(self.cwd, remotes, merges, target)
+        repo.aggregate()
+        last_rev = git_get_last_rev(self.cwd)
+        self.assertEqual(last_rev, self.commit_1_sha)
+
     def test_annotated_tag(self):
         remotes = [{
             'name': 'r1',


### PR DESCRIPTION
git clone do not care if the dir exist or is empty

And an existing target_dir/.git is expected in the rest of this function


Without this patch, if the dir is empty, an error is triggered here just after:
https://github.com/acsone/git-aggregator/blob/master/git_aggregator/repo.py#L298
