### PR TITLE
[ADD] depth argument for fetching limited git history globally

### DIFF
--- a/git_aggregator/config.py
+++ b/git_aggregator/config.py
@@ -130,7 +130,7 @@ def get_repos(config, force=False):
     return repo_list
 
 
-def load_config(config, expand_env=False, env_file=None, force=False):
+def load_config(config, expand_env=False, env_file=None, force=False, depth=0):
     """Return repos from a directory and fnmatch. Not recursive.
 
     :param config: paths to config file
@@ -140,6 +140,8 @@ def load_config(config, expand_env=False, env_file=None, force=False):
     :param env_file: path to file with variables to add to the environment.
     :type env_file: str or None
     :param bool force: True to aggregate even if repo is dirty.
+    :param int depth: Force depth of git repository to fetch. Default is 0
+                      (fetch all).
     :returns: expanded config dict item
     :rtype: iter(dict)
     """
@@ -172,5 +174,12 @@ def load_config(config, expand_env=False, env_file=None, force=False):
         config = open(config).read()
 
     conf = yaml.load(config, Loader=yaml.SafeLoader)
+
+    if depth > 0: # User wants to fetch only the last n commits
+        for repo_name, vals in conf.items():
+            if vals.get("defaults"):
+                conf[repo_name]["defaults"]["depth"] = depth
+            else:
+                conf[repo_name]["defaults"] = {"depth": depth}
 
     return get_repos(conf or {}, force)

--- a/git_aggregator/main.py
+++ b/git_aggregator/main.py
@@ -133,6 +133,15 @@ def get_parser():
     )
 
     main_parser.add_argument(
+        '-D', '--depth',
+        dest='depth',
+        default=0,
+        type=int,
+        help='Force depth of git repository to fetch. Default is 0 (fetch all). '
+             'This is useful on CI/CD environments to speed up the process. '
+             'Also, this will be ignore depth setting in the configuration file.',
+    )
+    main_parser.add_argument(
         '--no-color',
         dest='no_color',
         default=False,
@@ -245,7 +254,7 @@ def run(args):
     in args.command"""
 
     repos = load_config(
-        args.config, args.expand_env, args.env_file, args.force)
+        args.config, args.expand_env, args.env_file, args.force, args.depth)
 
     jobs = max(args.jobs, 1)
     threads = []

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -425,6 +425,7 @@ class TestRepo(unittest.TestCase):
             do_push=False,
             expand_env=False,
             env_file=None,
+            depth=0,
             force=False,
         )
 


### PR DESCRIPTION
Hello,

In CI/CD environments, fetching the Git history is often unnecessary and can significantly slow down the process. By adding this global depth parameter, users can limit the fetch depth to only the last n commits, reducing fetch times and optimizing workflows.

Usage
`gitaggregate -c repos.yml -D 1 --jobs 10`